### PR TITLE
Resolves #4 breaking the task upload loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This plugin does no actual stat tracking on its own. Instead, it siphons data fr
 ### config.yml
 ```yml
 language: english
+transfer-task-delay: 6000 # in server ticks. Default is 5 minutes
 sftp:
    host: localhost # The domain or IP that the plugin should attempt to upload to
    port: 22 # The port on which your SFTP server is listening
@@ -17,5 +18,6 @@ sftp:
 This plugin supports the following languages:
 
  - English - Original language
+ - Dutch - [Kyzegs](https://github.com/Kyzegs)
  - Bulgarian - [WolfNT90](https://github.com/WolfNT90)
  - Spanish - [nynxus](https://twitter.com/nynxus)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
 language: english
+transfer-task-delay: 6000
 sftp:
   host: localhost
   port: 22


### PR DESCRIPTION
- Moved task logic outside of StatTransfer#onEnable()
- Changed to Runnable instead of BukkitRunnable
- Switched from using runTaskTimer off of the BukkitRunnable object to runTaskLater inside of the server scheduler
- Implemented config value 'transfer-task-delay' that defaults to 6000 (results to around 5 minutes in testing)
- Updated README.md to include new config value in config preview, as well as add missed Dutch translation
- Plugin will now disable itself in case of config load failure